### PR TITLE
Edit events feature

### DIFF
--- a/app/Http/Livewire/EventsTable.php
+++ b/app/Http/Livewire/EventsTable.php
@@ -63,7 +63,8 @@ class EventsTable extends Component
     public function saveEvent()
     {
         foreach ($this->editedEvent as $key => $value) {
-            $this->eventBeingEdited[$key] = $this->editedEvent[$key];
+            $value = $value === "" ? NULL : $value;
+            $this->eventBeingEdited[$key] = $value;
         }
         $this->eventBeingEdited->save();
         $this->stopEditing();

--- a/resources/views/livewire/_editEventModal.blade.php
+++ b/resources/views/livewire/_editEventModal.blade.php
@@ -16,7 +16,7 @@
                 <div class="flex items-center mb-4 ">
                     <label for="email" class="mr-2 w-32 text-right font-bold">Date:</label>
                     <input type="date" class="p-2 border rounded w-full truncate" wire:model="editedEvent.date"
-                        value="{{$eventBeingEdited->date->format('Y-m-d')}}">
+                        value="{{$eventBeingEdited->date ? $eventBeingEdited->date->format('Y-m-d'): ''}}">
                 </div>
                 <div class="flex items-center mb-4">
                     <label for="role" class="mr-2 w-32 text-right font-bold">Speaker:</label>

--- a/resources/views/livewire/event.blade.php
+++ b/resources/views/livewire/event.blade.php
@@ -1,18 +1,18 @@
 <div>
     <button wire:click="vote(1)" class="{{$userVote === 1 ? 'text-green-700 hover:text-green-600 focus:outline-none' :'text-blue-800 hover:text-blue-600 focus:outline-none'}}">
-        @if($userVote === 1) 
+        @if($userVote === 1)
             <i class="fas fa-check-circle cursor-pointer"></i>
-             @else 
+             @else
             <i class="fas fa-arrow-circle-up cursor-pointer"></i>
         @endif
 
     </button>
-    <div class="text-4xl" wire:model="score">{{$score}}</div>
+    <div class="text-4xl">{{$score}}</div>
     <button wire:click="vote(-1)" class="{{$userVote === -1 ? 'text-stl-red hover:text-red-600 focus:outline-none' :'text-blue-800 hover:text-blue-600 focus:outline-none'}}">
-      @if($userVote === -1) 
+      @if($userVote === -1)
             <i class="fas fa-check-circle cursor-pointer"></i>
-             @else 
+             @else
             <i class="fas fa-arrow-circle-down cursor-pointer"></i>
-        @endif 
+        @endif
     </button>
 </div>

--- a/resources/views/livewire/events-table.blade.php
+++ b/resources/views/livewire/events-table.blade.php
@@ -22,7 +22,7 @@
                         </button>
                     </td>
                     <td class="px-4 py-2">{{$event->topic}}</td>
-                    <td class="px-4 py-2">{{$event->date->format('Y-m-d')}}</td>
+                    <td class="px-4 py-2">{{$event->date ? $event->date->format('Y-m-d') : 'Not Scheduled Yet'}}</td>
                     <td class="px-4 py-2">{{$event->speaker}}</td>
                     <td class="px-4 py-2">{{$event->video_url}}</td>
                     <td class="px-4 py-2">{{$event->createdBy->name}}</td>


### PR DESCRIPTION
Thanks for the earlier feedback, Kevin.  Actually I had never run into this before. So it seems that when deleting the date it was providing an empty string back to the DB on save. I believe there used to be a middleware that handled the conversion of empty strings to NULL in previous versions of Laravel but it looks like it no longer exists. I do recall it being mentioned it was going to be removed some time ago.  Anyways, interesting bug but I think I have it working again.